### PR TITLE
chore: migrations, docs & rios route fix

### DIFF
--- a/.github/workflows/backend-checks.yml
+++ b/.github/workflows/backend-checks.yml
@@ -1,0 +1,36 @@
+name: Backend checks (PR)
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+jobs:
+  backend-checks:
+    name: Backend checks
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+
+      - name: Install backend dependencies
+        run: npm --prefix backend ci
+
+      - name: Run backend checks (smoke / env loader)
+        run: npm --prefix backend run check
+
+      - name: Run backend unit tests
+        run: npm --prefix backend test
+
+      - name: Upload test results (logs)
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: backend-check-logs
+          path: |
+            backend/tests/**
+            backend/*.log

--- a/.github/workflows/backend-checks.yml
+++ b/.github/workflows/backend-checks.yml
@@ -18,7 +18,7 @@ jobs:
           node-version: '24'
 
       - name: Install backend dependencies
-        run: npm --prefix backend install
+        run: npm --prefix backend ci
 
       - name: Run backend checks (smoke / env loader)
         run: npm --prefix backend run check

--- a/.github/workflows/backend-checks.yml
+++ b/.github/workflows/backend-checks.yml
@@ -33,7 +33,7 @@ jobs:
           node <<'JS'
           const sqlite3 = require('sqlite3').verbose();
           const path = require('path');
-          const dbFile = path.join(__dirname, '..', 'data.sqlite');
+          const dbFile = path.resolve(process.cwd(), 'data.sqlite');
           const db = new sqlite3.Database(dbFile);
           db.serialize(() => {
             db.run("CREATE TABLE IF NOT EXISTS usuarios (id TEXT PRIMARY KEY, nombre TEXT, email TEXT)");

--- a/.github/workflows/backend-checks.yml
+++ b/.github/workflows/backend-checks.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Prepare sqlite DB for tests
         run: |
           cd backend
-          node -e "const sqlite3=require('sqlite3').verbose();const db=new sqlite3.Database('test.db');db.serialize(()=>{db.run('CREATE TABLE IF NOT EXISTS usuarios (id TEXT PRIMARY KEY, email TEXT)');}); db.close();"
+          node -e "const sqlite3=require('sqlite3').verbose();const path=require('path');const dbFile=path.join(__dirname,'..','data.sqlite');const db=new sqlite3.Database(dbFile);db.serialize(()=>{db.run('CREATE TABLE IF NOT EXISTS usuarios (id TEXT PRIMARY KEY, nombre TEXT, email TEXT)');db.run(`CREATE TABLE IF NOT EXISTS rios (id TEXT PRIMARY KEY, nombre TEXT, descripcion TEXT, categoria TEXT, dificultad TEXT, duracion_estimada INTEGER, geometry TEXT, multimedia TEXT, lat REAL, lng REAL)`);}); db.close();"
 
       - name: Run backend checks (smoke / env loader)
         run: npm --prefix backend run check

--- a/.github/workflows/backend-checks.yml
+++ b/.github/workflows/backend-checks.yml
@@ -24,8 +24,33 @@ jobs:
       - name: Install backend dependencies
         run: npm --prefix backend ci
 
-      - name: Start dummy HTTP server
-        run: python3 -m http.server 9000 &
+      - name: Start dummy HTTP server (Node)
+        run: |
+          cat > dummy-server.js <<'JS'
+          const http = require('http');
+          const url = require('url');
+
+          const server = http.createServer((req, res) => {
+            const parsed = url.parse(req.url, true);
+            if (req.method === 'POST' && parsed.pathname === '/api/multimedia/upload') {
+              let body = '';
+              req.on('data', chunk => body += chunk);
+              req.on('end', () => {
+                res.writeHead(200, {'Content-Type': 'application/json'});
+                res.end(JSON.stringify({ ok: true, id: 'ci-mock' }));
+              });
+              return;
+            }
+            // default: simple 200 JSON for any GET
+            res.writeHead(200, {'Content-Type': 'application/json'});
+            res.end(JSON.stringify({ ok: true }));
+          });
+
+          server.listen(9000, '127.0.0.1');
+          // keep process alive in background
+          console.log('dummy server listening on 9000');
+          JS
+          node dummy-server.js &
 
       - name: Prepare sqlite DB for tests
         run: |

--- a/.github/workflows/backend-checks.yml
+++ b/.github/workflows/backend-checks.yml
@@ -8,6 +8,10 @@ jobs:
   backend-checks:
     name: Backend checks
     runs-on: ubuntu-latest
+    env:
+      CLEANUP_SMTP_USER: 'ci@example.invalid'
+      CLEANUP_SMTP_PASS: 'ci'
+      CLEANUP_SMTP_HOST: 'localhost'
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -19,6 +23,14 @@ jobs:
 
       - name: Install backend dependencies
         run: npm --prefix backend ci
+
+      - name: Start dummy HTTP server
+        run: python3 -m http.server 9000 &
+
+      - name: Prepare sqlite DB for tests
+        run: |
+          cd backend
+          node -e "const sqlite3=require('sqlite3').verbose();const db=new sqlite3.Database('test.db');db.serialize(()=>{db.run('CREATE TABLE IF NOT EXISTS usuarios (id TEXT PRIMARY KEY, email TEXT)');}); db.close();"
 
       - name: Run backend checks (smoke / env loader)
         run: npm --prefix backend run check

--- a/.github/workflows/backend-checks.yml
+++ b/.github/workflows/backend-checks.yml
@@ -30,7 +30,17 @@ jobs:
       - name: Prepare sqlite DB for tests
         run: |
           cd backend
-          node -e "const sqlite3=require('sqlite3').verbose();const path=require('path');const dbFile=path.join(__dirname,'..','data.sqlite');const db=new sqlite3.Database(dbFile);db.serialize(()=>{db.run('CREATE TABLE IF NOT EXISTS usuarios (id TEXT PRIMARY KEY, nombre TEXT, email TEXT)');db.run(`CREATE TABLE IF NOT EXISTS rios (id TEXT PRIMARY KEY, nombre TEXT, descripcion TEXT, categoria TEXT, dificultad TEXT, duracion_estimada INTEGER, geometry TEXT, multimedia TEXT, lat REAL, lng REAL)`);}); db.close();"
+          node <<'JS'
+          const sqlite3 = require('sqlite3').verbose();
+          const path = require('path');
+          const dbFile = path.join(__dirname, '..', 'data.sqlite');
+          const db = new sqlite3.Database(dbFile);
+          db.serialize(() => {
+            db.run("CREATE TABLE IF NOT EXISTS usuarios (id TEXT PRIMARY KEY, nombre TEXT, email TEXT)");
+            db.run("CREATE TABLE IF NOT EXISTS rios (id TEXT PRIMARY KEY, nombre TEXT, descripcion TEXT, categoria TEXT, dificultad TEXT, duracion_estimada INTEGER, geometry TEXT, multimedia TEXT, lat REAL, lng REAL)");
+          });
+          db.close();
+          JS
 
       - name: Run backend checks (smoke / env loader)
         run: npm --prefix backend run check

--- a/.github/workflows/backend-checks.yml
+++ b/.github/workflows/backend-checks.yml
@@ -18,7 +18,7 @@ jobs:
           node-version: '24'
 
       - name: Install backend dependencies
-        run: npm --prefix backend ci
+        run: npm --prefix backend install
 
       - name: Run backend checks (smoke / env loader)
         run: npm --prefix backend run check

--- a/.github/workflows/create_pr_from_chore.yml
+++ b/.github/workflows/create_pr_from_chore.yml
@@ -9,6 +9,9 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+    env:
+      # optional PAT secret: if present, the workflow will use it to create the PR
+      PR_TOKEN: ${{ secrets.CREATE_PR_PAT }}
 
     steps:
       - name: Checkout
@@ -23,21 +26,41 @@ jobs:
             const title = 'chore: docs and migrations — migration notes & scripts';
             const body = 'Añade MIGRATION_NOTES y scripts de migración (run_migrations.ps1). Mover docs a PR para revisión.';
 
+            // decide which token to use: optional secret PAT or the default GITHUB_TOKEN
+            const token = process.env.PR_TOKEN || process.env.GITHUB_TOKEN;
+            let oct;
+            if (token && token !== process.env.GITHUB_TOKEN) {
+              // create an authenticated client using the provided PAT
+              const { getOctokit } = require('@actions/github');
+              oct = getOctokit(token);
+            } else {
+              // fall back to the provided 'github' client (uses GITHUB_TOKEN)
+              oct = github;
+            }
+
             // verify branch exists
             try {
-              await github.rest.repos.getBranch({ owner: context.repo.owner, repo: context.repo.repo, branch: head });
+              await oct.rest.repos.getBranch({ owner: context.repo.owner, repo: context.repo.repo, branch: head });
             } catch (err) {
               core.setFailed(`Branch ${head} not found: ${err.message}`);
             }
 
             // check if a PR from head->base already exists
-            const existing = await github.rest.pulls.list({ owner: context.repo.owner, repo: context.repo.repo, head: `${context.repo.owner}:${head}`, base });
+            const existing = await oct.rest.pulls.list({ owner: context.repo.owner, repo: context.repo.repo, head: `${context.repo.owner}:${head}`, base });
             if (existing.data && existing.data.length > 0) {
               console.log(`PR already exists: ${existing.data[0].html_url}`);
               return;
             }
 
-            // create the PR
-            const pr = await github.rest.pulls.create({ owner: context.repo.owner, repo: context.repo.repo, head, base, title, body });
-            console.log(`PR created: ${pr.data.html_url}`);
-            return pr.data.html_url;
+            // try to create the PR; if 403 and we attempted with GITHUB_TOKEN, give clear instructions
+            try {
+              const pr = await oct.rest.pulls.create({ owner: context.repo.owner, repo: context.repo.repo, head, base, title, body });
+              console.log(`PR created: ${pr.data.html_url}`);
+              return pr.data.html_url;
+            } catch (err) {
+              if (err && err.status === 403 && (!process.env.PR_TOKEN || process.env.PR_TOKEN === '')) {
+                core.setFailed('GitHub Actions is not permitted to create pull requests with the default token in this repository. Add a Personal Access Token as the repository secret `CREATE_PR_PAT` with `repo` scope and re-run this workflow.');
+              } else {
+                core.setFailed(err.message || String(err));
+              }
+            }

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -12,8 +12,9 @@
         "dotenv": "^16.0.3",
         "exif-parser": "^0.1.12",
         "express": "^4.18.2",
-        "firebase-admin": "^11.10.0",
+        "firebase-admin": "^13.4.0",
         "form-data": "^4.0.4",
+        "joi": "^17.9.2",
         "multer": "^1.4.5-lts.1",
         "node-fetch": "^2.7.0",
         "nodemailer": "^6.10.1",
@@ -22,147 +23,114 @@
         "uuid": "^9.0.0"
       },
       "devDependencies": {
-        "nodemon": "^2.0.22"
-      }
-    },
-    "node_modules/@babel/helper-string-parser": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.27.1.tgz",
-      "integrity": "sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/parser": {
-      "version": "7.28.3",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.3.tgz",
-      "integrity": "sha512-7+Ey1mAgYqFAx2h0RuoxcQT5+MlG3GTV0TQrgr7/ZliKsm/MNDxVVutlWaziMq7wJNAz8MTqz55XLpWvva6StA==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@babel/types": "^7.28.2"
-      },
-      "bin": {
-        "parser": "bin/babel-parser.js"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
-    "node_modules/@babel/types": {
-      "version": "7.28.2",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.2.tgz",
-      "integrity": "sha512-ruv7Ae4J5dUYULmeXw1gmb7rYRz57OWCPM57pHojnLq/3Z1CK2lNSLTCVjxVk1F/TZHwOZZrOWi0ur95BbLxNQ==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@babel/helper-string-parser": "^7.27.1",
-        "@babel/helper-validator-identifier": "^7.27.1"
-      },
-      "engines": {
-        "node": ">=6.9.0"
+        "nodemon": "^3.1.10"
       }
     },
     "node_modules/@fastify/busboy": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-1.2.1.tgz",
-      "integrity": "sha512-7PQA7EH43S0CxcOa9OeAnaeA0oQ+e/DHNPZwSQM9CQHW76jle5+OvLdibRp/Aafs9KXbLhxyjOTkRjWUbQEd3Q==",
-      "license": "MIT",
-      "dependencies": {
-        "text-decoding": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=14"
-      }
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-3.2.0.tgz",
+      "integrity": "sha512-m9FVDXU3GT2ITSe0UaMA5rU3QkfC/UXtCU8y0gSN/GugTqtVldOBWIB5V6V3sbmenVZUIpU6f+mPEO2+m5iTaA==",
+      "license": "MIT"
+    },
+    "node_modules/@firebase/app-check-interop-types": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/@firebase/app-check-interop-types/-/app-check-interop-types-0.3.3.tgz",
+      "integrity": "sha512-gAlxfPLT2j8bTI/qfe3ahl2I2YcBQ8cFIBdhAQA4I2f3TndcO+22YizyGYuttLHPQEpWkhmpFW60VCFEPg4g5A==",
+      "license": "Apache-2.0"
     },
     "node_modules/@firebase/app-types": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/@firebase/app-types/-/app-types-0.9.0.tgz",
-      "integrity": "sha512-AeweANOIo0Mb8GiYm3xhTEBVCmPwTYAu9Hcd2qSkLuga/6+j9b1Jskl5bpiSQWy9eJ/j5pavxj6eYogmnuzm+Q==",
+      "version": "0.9.3",
+      "resolved": "https://registry.npmjs.org/@firebase/app-types/-/app-types-0.9.3.tgz",
+      "integrity": "sha512-kRVpIl4vVGJ4baogMDINbyrIOtOxqhkZQg4jTq3l8Lw6WSk0xfpEYzezFu+Kl4ve4fbPl79dvwRtaFqAC/ucCw==",
       "license": "Apache-2.0"
     },
     "node_modules/@firebase/auth-interop-types": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/@firebase/auth-interop-types/-/auth-interop-types-0.2.1.tgz",
-      "integrity": "sha512-VOaGzKp65MY6P5FI84TfYKBXEPi6LmOCSMMzys6o2BN2LOsqy7pCuZCup7NYnfbk5OkkQKzvIfHOzTm0UDpkyg==",
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@firebase/auth-interop-types/-/auth-interop-types-0.2.4.tgz",
+      "integrity": "sha512-JPgcXKCuO+CWqGDnigBtvo09HeBs5u/Ktc2GaFj2m01hLarbxthLNm7Fk8iOP1aqAtXV+fnnGj7U28xmk7IwVA==",
       "license": "Apache-2.0"
     },
     "node_modules/@firebase/component": {
-      "version": "0.6.4",
-      "resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.6.4.tgz",
-      "integrity": "sha512-rLMyrXuO9jcAUCaQXCMjCMUsWrba5fzHlNK24xz5j2W6A/SRmK8mZJ/hn7V0fViLbxC0lPMtrK1eYzk6Fg03jA==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.7.0.tgz",
+      "integrity": "sha512-wR9En2A+WESUHexjmRHkqtaVH94WLNKt6rmeqZhSLBybg4Wyf0Umk04SZsS6sBq4102ZsDBFwoqMqJYj2IoDSg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/util": "1.9.3",
+        "@firebase/util": "1.13.0",
         "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@firebase/database": {
-      "version": "0.14.4",
-      "resolved": "https://registry.npmjs.org/@firebase/database/-/database-0.14.4.tgz",
-      "integrity": "sha512-+Ea/IKGwh42jwdjCyzTmeZeLM3oy1h0mFPsTy6OqCWzcu/KFqRAr5Tt1HRCOBlNOdbh84JPZC47WLU18n2VbxQ==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@firebase/database/-/database-1.1.0.tgz",
+      "integrity": "sha512-gM6MJFae3pTyNLoc9VcJNuaUDej0ctdjn3cVtILo3D5lpp0dmUHHLFN/pUKe7ImyeB1KAvRlEYxvIHNF04Filg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/auth-interop-types": "0.2.1",
-        "@firebase/component": "0.6.4",
-        "@firebase/logger": "0.4.0",
-        "@firebase/util": "1.9.3",
+        "@firebase/app-check-interop-types": "0.3.3",
+        "@firebase/auth-interop-types": "0.2.4",
+        "@firebase/component": "0.7.0",
+        "@firebase/logger": "0.5.0",
+        "@firebase/util": "1.13.0",
         "faye-websocket": "0.11.4",
         "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@firebase/database-compat": {
-      "version": "0.3.4",
-      "resolved": "https://registry.npmjs.org/@firebase/database-compat/-/database-compat-0.3.4.tgz",
-      "integrity": "sha512-kuAW+l+sLMUKBThnvxvUZ+Q1ZrF/vFJ58iUY9kAcbX48U03nVzIF6Tmkf0p3WVQwMqiXguSgtOPIB6ZCeF+5Gg==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@firebase/database-compat/-/database-compat-2.1.0.tgz",
+      "integrity": "sha512-8nYc43RqxScsePVd1qe1xxvWNf0OBnbwHxmXJ7MHSuuTVYFO3eLyLW3PiCKJ9fHnmIz4p4LbieXwz+qtr9PZDg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/component": "0.6.4",
-        "@firebase/database": "0.14.4",
-        "@firebase/database-types": "0.10.4",
-        "@firebase/logger": "0.4.0",
-        "@firebase/util": "1.9.3",
+        "@firebase/component": "0.7.0",
+        "@firebase/database": "1.1.0",
+        "@firebase/database-types": "1.0.16",
+        "@firebase/logger": "0.5.0",
+        "@firebase/util": "1.13.0",
         "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@firebase/database-types": {
-      "version": "0.10.4",
-      "resolved": "https://registry.npmjs.org/@firebase/database-types/-/database-types-0.10.4.tgz",
-      "integrity": "sha512-dPySn0vJ/89ZeBac70T+2tWWPiJXWbmRygYv0smT5TfE3hDrQ09eKMF3Y+vMlTdrMWq7mUdYW5REWPSGH4kAZQ==",
+      "version": "1.0.16",
+      "resolved": "https://registry.npmjs.org/@firebase/database-types/-/database-types-1.0.16.tgz",
+      "integrity": "sha512-xkQLQfU5De7+SPhEGAXFBnDryUWhhlFXelEg2YeZOQMCdoe7dL64DDAd77SQsR+6uoXIZY5MB4y/inCs4GTfcw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebase/app-types": "0.9.0",
-        "@firebase/util": "1.9.3"
+        "@firebase/app-types": "0.9.3",
+        "@firebase/util": "1.13.0"
       }
     },
     "node_modules/@firebase/logger": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@firebase/logger/-/logger-0.4.0.tgz",
-      "integrity": "sha512-eRKSeykumZ5+cJPdxxJRgAC3G5NknY2GwEbKfymdnXtnT0Ucm4pspfR6GT4MUQEDuJwRVbVcSx85kgJulMoFFA==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@firebase/logger/-/logger-0.5.0.tgz",
+      "integrity": "sha512-cGskaAvkrnh42b3BA3doDWeBmuHFO/Mx5A83rbRDYakPjO9bJtRL3dX7javzc2Rr/JHZf4HlterTW2lUkfeN4g==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@firebase/util": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/@firebase/util/-/util-1.9.3.tgz",
-      "integrity": "sha512-DY02CRhOZwpzO36fHpuVysz6JZrscPiBXD0fXp6qSrL9oNOx5KWICKdR95C0lSITzxp0TZosVyHqzatE8JbcjA==",
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/@firebase/util/-/util-1.13.0.tgz",
+      "integrity": "sha512-0AZUyYUfpMNcztR5l09izHwXkZpghLgCUaAGjtMwXnCg3bj4ml5VgiwqOMOxJ+Nw4qN/zJAaOQBcJ7KGkWStqQ==",
+      "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@gar/promisify": {
@@ -173,25 +141,26 @@
       "optional": true
     },
     "node_modules/@google-cloud/firestore": {
-      "version": "6.8.0",
-      "resolved": "https://registry.npmjs.org/@google-cloud/firestore/-/firestore-6.8.0.tgz",
-      "integrity": "sha512-JRpk06SmZXLGz0pNx1x7yU3YhkUXheKgH5hbDZ4kMsdhtfV5qPLJLRI4wv69K0cZorIk+zTMOwptue7hizo0eA==",
+      "version": "7.11.3",
+      "resolved": "https://registry.npmjs.org/@google-cloud/firestore/-/firestore-7.11.3.tgz",
+      "integrity": "sha512-qsM3/WHpawF07SRVvEJJVRwhYzM7o9qtuksyuqnrMig6fxIrwWnsezECWsG/D5TyYru51Fv5c/RTqNDQ2yU+4w==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
+        "@opentelemetry/api": "^1.3.0",
         "fast-deep-equal": "^3.1.1",
         "functional-red-black-tree": "^1.0.1",
-        "google-gax": "^3.5.7",
-        "protobufjs": "^7.2.5"
+        "google-gax": "^4.3.3",
+        "protobufjs": "^7.2.6"
       },
       "engines": {
-        "node": ">=12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@google-cloud/paginator": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/@google-cloud/paginator/-/paginator-3.0.7.tgz",
-      "integrity": "sha512-jJNutk0arIQhmpUUQJPJErsojqo834KcyB6X7a1mxuic8i1tKXxde8E69IZxNZawRIlZdIK2QY4WALvlK5MzYQ==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@google-cloud/paginator/-/paginator-5.0.2.tgz",
+      "integrity": "sha512-DJS3s0OVH4zFDB1PzjxAsHqJT6sKVbRwwML0ZBP9PbU7Yebtu/7SWMRzvO2J3nUi9pRNITCfu4LJeooM2w4pjg==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
@@ -199,57 +168,54 @@
         "extend": "^3.0.2"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@google-cloud/projectify": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@google-cloud/projectify/-/projectify-3.0.0.tgz",
-      "integrity": "sha512-HRkZsNmjScY6Li8/kb70wjGlDDyLkVk3KvoEo9uIoxSjYLJasGiCch9+PqRVDOCGUFvEIqyogl+BeqILL4OJHA==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@google-cloud/projectify/-/projectify-4.0.0.tgz",
+      "integrity": "sha512-MmaX6HeSvyPbWGwFq7mXdo0uQZLGBYCwziiLIGq5JVX+/bdI3SAq6bP98trV5eTWfLuvsMcIC1YJOF2vfteLFA==",
       "license": "Apache-2.0",
       "optional": true,
       "engines": {
-        "node": ">=12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@google-cloud/promisify": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@google-cloud/promisify/-/promisify-3.0.1.tgz",
-      "integrity": "sha512-z1CjRjtQyBOYL+5Qr9DdYIfrdLBe746jRTYfaYU6MeXkqp7UfYs/jX16lFFVzZ7PGEJvqZNqYUEtb1mvDww4pA==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@google-cloud/promisify/-/promisify-4.0.0.tgz",
+      "integrity": "sha512-Orxzlfb9c67A15cq2JQEyVc7wEsmFBmHjZWZYQMUyJ1qivXyMwdyNOs9odi79hze+2zqdTtu1E19IM/FtqZ10g==",
       "license": "Apache-2.0",
       "optional": true,
       "engines": {
-        "node": ">=12"
+        "node": ">=14"
       }
     },
     "node_modules/@google-cloud/storage": {
-      "version": "6.12.0",
-      "resolved": "https://registry.npmjs.org/@google-cloud/storage/-/storage-6.12.0.tgz",
-      "integrity": "sha512-78nNAY7iiZ4O/BouWMWTD/oSF2YtYgYB3GZirn0To6eBOugjXVoK+GXgUXOl+HlqbAOyHxAVXOlsj3snfbQ1dw==",
+      "version": "7.17.0",
+      "resolved": "https://registry.npmjs.org/@google-cloud/storage/-/storage-7.17.0.tgz",
+      "integrity": "sha512-5m9GoZqKh52a1UqkxDBu/+WVFDALNtHg5up5gNmNbXQWBcV813tzJKsyDtKjOPrlR1em1TxtD7NSPCrObH7koQ==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
-        "@google-cloud/paginator": "^3.0.7",
-        "@google-cloud/projectify": "^3.0.0",
-        "@google-cloud/promisify": "^3.0.0",
+        "@google-cloud/paginator": "^5.0.0",
+        "@google-cloud/projectify": "^4.0.0",
+        "@google-cloud/promisify": "<4.1.0",
         "abort-controller": "^3.0.0",
         "async-retry": "^1.3.3",
-        "compressible": "^2.0.12",
-        "duplexify": "^4.0.0",
-        "ent": "^2.2.0",
-        "extend": "^3.0.2",
-        "fast-xml-parser": "^4.2.2",
-        "gaxios": "^5.0.0",
-        "google-auth-library": "^8.0.1",
+        "duplexify": "^4.1.3",
+        "fast-xml-parser": "^4.4.1",
+        "gaxios": "^6.0.2",
+        "google-auth-library": "^9.6.3",
+        "html-entities": "^2.5.2",
         "mime": "^3.0.0",
-        "mime-types": "^2.0.8",
         "p-limit": "^3.0.1",
-        "retry-request": "^5.0.0",
-        "teeny-request": "^8.0.0",
+        "retry-request": "^7.0.0",
+        "teeny-request": "^9.0.0",
         "uuid": "^8.0.0"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=14"
       }
     },
     "node_modules/@google-cloud/storage/node_modules/uuid": {
@@ -263,17 +229,17 @@
       }
     },
     "node_modules/@grpc/grpc-js": {
-      "version": "1.8.22",
-      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.8.22.tgz",
-      "integrity": "sha512-oAjDdN7fzbUi+4hZjKG96MR6KTEubAeMpQEb+77qy+3r0Ua5xTFuie6JOLr4ZZgl5g+W5/uRTS2M1V8mVAFPuA==",
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.13.4.tgz",
+      "integrity": "sha512-GsFaMXCkMqkKIvwCQjCrwH+GHbPKBjhwo/8ZuUkWHqbI73Kky9I+pQltrlT0+MWpedCoosda53lgjYfyEPgxBg==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
-        "@grpc/proto-loader": "^0.7.0",
-        "@types/node": ">=12.12.47"
+        "@grpc/proto-loader": "^0.7.13",
+        "@js-sdsl/ordered-map": "^4.4.2"
       },
       "engines": {
-        "node": "^8.13.0 || >=10.10.0"
+        "node": ">=12.10.0"
       }
     },
     "node_modules/@grpc/proto-loader": {
@@ -295,17 +261,30 @@
         "node": ">=6"
       }
     },
-    "node_modules/@jsdoc/salty": {
-      "version": "0.2.9",
-      "resolved": "https://registry.npmjs.org/@jsdoc/salty/-/salty-0.2.9.tgz",
-      "integrity": "sha512-yYxMVH7Dqw6nO0d5NIV8OQWnitU8k6vXH8NtgqAfIa/IUqRMxRv/NUJJ08VEKbAakwxlgBl5PJdrU0dMPStsnw==",
-      "license": "Apache-2.0",
-      "optional": true,
+    "node_modules/@hapi/hoek": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.3.0.tgz",
+      "integrity": "sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@hapi/topo": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-5.1.0.tgz",
+      "integrity": "sha512-foQZKJig7Ob0BMAYBfcJk8d77QtOe7Wo4ox7ff1lQYoNNAb6jwcY1ncdoy2e9wQZzvNy7ODZCYJkK8kzmcAnAg==",
+      "license": "BSD-3-Clause",
       "dependencies": {
-        "lodash": "^4.17.21"
-      },
-      "engines": {
-        "node": ">=v12.0.0"
+        "@hapi/hoek": "^9.0.0"
+      }
+    },
+    "node_modules/@js-sdsl/ordered-map": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@js-sdsl/ordered-map/-/ordered-map-4.4.2.tgz",
+      "integrity": "sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw==",
+      "license": "MIT",
+      "optional": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/js-sdsl"
       }
     },
     "node_modules/@npmcli/fs": {
@@ -345,6 +324,16 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
+      "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "engines": {
+        "node": ">=8.0.0"
       }
     },
     "node_modules/@protobufjs/aspromise": {
@@ -421,6 +410,27 @@
       "license": "BSD-3-Clause",
       "optional": true
     },
+    "node_modules/@sideway/address": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.5.tgz",
+      "integrity": "sha512-IqO/DUQHUkPeixNQ8n0JA6102hT9CmaljNTPmQ1u8MEhBo/R4Q8eKLN/vGZxuebwOroDB4cbpjheD4+/sKFK4Q==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@hapi/hoek": "^9.0.0"
+      }
+    },
+    "node_modules/@sideway/formula": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@sideway/formula/-/formula-3.0.1.tgz",
+      "integrity": "sha512-/poHZJJVjx3L+zVD6g9KgHfYnb443oi7wLu/XKojDviHy6HOEOA6z1Trk5aR1dGcmPenJEgb2sK2I80LeS3MIg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@sideway/pinpoint": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@sideway/pinpoint/-/pinpoint-2.0.0.tgz",
+      "integrity": "sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/@tootallnate/once": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
@@ -440,6 +450,13 @@
         "@types/connect": "*",
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/caseless": {
+      "version": "0.12.5",
+      "resolved": "https://registry.npmjs.org/@types/caseless/-/caseless-0.12.5.tgz",
+      "integrity": "sha512-hWtVTC2q7hc7xZ/RLbxapMvDMgUnDvKvMOpKal4DrMyfGBUfB1oKaZlIRr6mJL+If3bAP6sV/QneGzF6tJjZDg==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/@types/connect": {
       "version": "3.4.38",
@@ -474,17 +491,6 @@
         "@types/send": "*"
       }
     },
-    "node_modules/@types/glob": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/@types/glob/-/glob-8.1.0.tgz",
-      "integrity": "sha512-IO+MJPVhoqz+28h1qLAcBEH2+xHMK6MTyHJc7MTnnYb6wsoLR29POVGJ7LycmVXIqyy/4/2ShP5sUwTXuOwb/w==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@types/minimatch": "^5.1.2",
-        "@types/node": "*"
-      }
-    },
     "node_modules/@types/http-errors": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.5.tgz",
@@ -501,35 +507,10 @@
         "@types/node": "*"
       }
     },
-    "node_modules/@types/linkify-it": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-5.0.0.tgz",
-      "integrity": "sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==",
-      "license": "MIT",
-      "optional": true
-    },
     "node_modules/@types/long": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.2.tgz",
       "integrity": "sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA==",
-      "license": "MIT",
-      "optional": true
-    },
-    "node_modules/@types/markdown-it": {
-      "version": "14.1.2",
-      "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-14.1.2.tgz",
-      "integrity": "sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@types/linkify-it": "^5",
-        "@types/mdurl": "^2"
-      }
-    },
-    "node_modules/@types/mdurl": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-2.0.0.tgz",
-      "integrity": "sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==",
       "license": "MIT",
       "optional": true
     },
@@ -538,13 +519,6 @@
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.5.tgz",
       "integrity": "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==",
       "license": "MIT"
-    },
-    "node_modules/@types/minimatch": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-5.1.2.tgz",
-      "integrity": "sha512-K0VQKziLUWkVKiRVrx4a40iPaxTUefQmjtkQofBkYRcoaaL/8rhwDWww9qWbrgicNOgnpIsMxyNIUM4+n6dUIA==",
-      "license": "MIT",
-      "optional": true
     },
     "node_modules/@types/ms": {
       "version": "2.1.0",
@@ -573,15 +547,35 @@
       "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
       "license": "MIT"
     },
-    "node_modules/@types/rimraf": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@types/rimraf/-/rimraf-3.0.2.tgz",
-      "integrity": "sha512-F3OznnSLAUxFrCEu/L5PY8+ny8DtcFRjx7fZZ9bycvXRi3KPTRS9HOitGZwvPg0juRhXFWIeKX58cnX5YqLohQ==",
+    "node_modules/@types/request": {
+      "version": "2.48.13",
+      "resolved": "https://registry.npmjs.org/@types/request/-/request-2.48.13.tgz",
+      "integrity": "sha512-FGJ6udDNUCjd19pp0Q3iTiDkwhYup7J8hpMW9c4k53NrccQFFWKRho6hvtPPEhnXWKvukfwAlB6DbDz4yhH5Gg==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@types/glob": "*",
-        "@types/node": "*"
+        "@types/caseless": "*",
+        "@types/node": "*",
+        "@types/tough-cookie": "*",
+        "form-data": "^2.5.5"
+      }
+    },
+    "node_modules/@types/request/node_modules/form-data": {
+      "version": "2.5.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.5.tgz",
+      "integrity": "sha512-jqdObeR2rxZZbPSGL+3VckHMYtu+f9//KXBsVny6JSX/pa38Fy+bGjuG8eW/H6USNQWhLi8Num++cU2yOCNz4A==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.35",
+        "safe-buffer": "^5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.12"
       }
     },
     "node_modules/@types/send": {
@@ -604,6 +598,13 @@
         "@types/node": "*",
         "@types/send": "*"
       }
+    },
+    "node_modules/@types/tough-cookie": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
+      "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/abbrev": {
       "version": "1.1.1",
@@ -636,29 +637,6 @@
       },
       "engines": {
         "node": ">= 0.6"
-      }
-    },
-    "node_modules/acorn": {
-      "version": "8.15.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
-      "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
-      "license": "MIT",
-      "optional": true,
-      "bin": {
-        "acorn": "bin/acorn"
-      },
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
-    "node_modules/acorn-jsx": {
-      "version": "5.3.2",
-      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
-      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-      "license": "MIT",
-      "optional": true,
-      "peerDependencies": {
-        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
     "node_modules/agent-base": {
@@ -793,13 +771,6 @@
       "engines": {
         "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
-    },
-    "node_modules/argparse": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "license": "Python-2.0",
-      "optional": true
     },
     "node_modules/array-flatten": {
       "version": "1.1.1",
@@ -943,7 +914,6 @@
       "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
       "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": "*"
       }
@@ -980,13 +950,6 @@
         "inherits": "^2.0.4",
         "readable-stream": "^3.4.0"
       }
-    },
-    "node_modules/bluebird": {
-      "version": "3.7.2",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
-      "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
-      "license": "MIT",
-      "optional": true
     },
     "node_modules/body-parser": {
       "version": "1.20.3",
@@ -1186,59 +1149,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/catharsis": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/catharsis/-/catharsis-0.9.0.tgz",
-      "integrity": "sha512-prMTQVpcns/tzFgFVkVp6ak6RykZyWb3gu8ckUpd6YkTlacOd3DXGJjIpD4Q6zJirizvaiAjSSHlOsA+6sNh2A==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "lodash": "^4.17.15"
-      },
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/chalk/node_modules/has-flag": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/chalk/node_modules/supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/chokidar": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
@@ -1359,19 +1269,6 @@
       },
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/compressible": {
-      "version": "2.0.18",
-      "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.18.tgz",
-      "integrity": "sha512-AF3r7P5dWxL8MxyITRMlORQNaOA2IkAFaTr4k7BUumjPtRpGDTZpl0Pb1XCO6JeDCBdp126Cgs9sMxqSjgYyRg==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "mime-db": ">= 1.43.0 < 2"
-      },
-      "engines": {
-        "node": ">= 0.6"
       }
     },
     "node_modules/concat-map": {
@@ -1521,13 +1418,6 @@
         "node": ">=4.0.0"
       }
     },
-    "node_modules/deep-is": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
-      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
-      "license": "MIT",
-      "optional": true
-    },
     "node_modules/delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
@@ -1674,35 +1564,6 @@
         "once": "^1.4.0"
       }
     },
-    "node_modules/ent": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/ent/-/ent-2.2.2.tgz",
-      "integrity": "sha512-kKvD1tO6BM+oK9HzCPpUdRb4vKFQY/FPTFmurMvh6LlN68VMrdj77w8yp51/kDbpkFOS9J8w5W6zIzgM2H8/hw==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "call-bound": "^1.0.3",
-        "es-errors": "^1.3.0",
-        "punycode": "^1.4.1",
-        "safe-regex-test": "^1.1.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/entities": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
-      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
-      "license": "BSD-2-Clause",
-      "optional": true,
-      "engines": {
-        "node": ">=0.12"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/entities?sponsor=1"
-      }
-    },
     "node_modules/env-paths": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
@@ -1780,114 +1641,6 @@
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
       "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
       "license": "MIT"
-    },
-    "node_modules/escape-string-regexp": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
-      "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/escodegen": {
-      "version": "1.14.3",
-      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.14.3.tgz",
-      "integrity": "sha512-qFcX0XJkdg+PB3xjZZG/wKSuT1PnQWx57+TVSjIMmILd2yC/6ByYElPwJnslDsuWuSAp4AwJGumarAAmJch5Kw==",
-      "license": "BSD-2-Clause",
-      "optional": true,
-      "dependencies": {
-        "esprima": "^4.0.1",
-        "estraverse": "^4.2.0",
-        "esutils": "^2.0.2",
-        "optionator": "^0.8.1"
-      },
-      "bin": {
-        "escodegen": "bin/escodegen.js",
-        "esgenerate": "bin/esgenerate.js"
-      },
-      "engines": {
-        "node": ">=4.0"
-      },
-      "optionalDependencies": {
-        "source-map": "~0.6.1"
-      }
-    },
-    "node_modules/escodegen/node_modules/estraverse": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
-      "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
-      "license": "BSD-2-Clause",
-      "optional": true,
-      "engines": {
-        "node": ">=4.0"
-      }
-    },
-    "node_modules/eslint-visitor-keys": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
-      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
-      }
-    },
-    "node_modules/espree": {
-      "version": "9.6.1",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-9.6.1.tgz",
-      "integrity": "sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==",
-      "license": "BSD-2-Clause",
-      "optional": true,
-      "dependencies": {
-        "acorn": "^8.9.0",
-        "acorn-jsx": "^5.3.2",
-        "eslint-visitor-keys": "^3.4.1"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
-      }
-    },
-    "node_modules/esprima": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-      "license": "BSD-2-Clause",
-      "optional": true,
-      "bin": {
-        "esparse": "bin/esparse.js",
-        "esvalidate": "bin/esvalidate.js"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/estraverse": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
-      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
-      "license": "BSD-2-Clause",
-      "optional": true,
-      "engines": {
-        "node": ">=4.0"
-      }
-    },
-    "node_modules/esutils": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
-      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
-      "license": "BSD-2-Clause",
-      "optional": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
     },
     "node_modules/etag": {
       "version": "1.8.1",
@@ -1972,8 +1725,16 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "license": "MIT"
+    },
+    "node_modules/farmhash-modern": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/farmhash-modern/-/farmhash-modern-1.1.0.tgz",
+      "integrity": "sha512-6ypT4XfgqJk/F3Yuv4SX26I3doUjt0GTG4a+JgWxXQpxXzTBq8fPUeGHfcYMMDPHJHm3yPOSjaeBwBGAHWXCdA==",
       "license": "MIT",
-      "optional": true
+      "engines": {
+        "node": ">=18.0.0"
+      }
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -1987,20 +1748,6 @@
       "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
       "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
       "license": "MIT"
-    },
-    "node_modules/fast-levenshtein": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
-      "license": "MIT",
-      "optional": true
-    },
-    "node_modules/fast-text-encoding": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/fast-text-encoding/-/fast-text-encoding-1.0.6.tgz",
-      "integrity": "sha512-VhXlQgj9ioXCqGstD37E/HBeqEGV/qOD/kmbVG8h5xKBYvM1L3lR1Zn4555cQ8GkYbJa8aJSipLPndE1k6zK2w==",
-      "license": "Apache-2.0",
-      "optional": true
     },
     "node_modules/fast-xml-parser": {
       "version": "4.5.3",
@@ -2071,26 +1818,56 @@
       }
     },
     "node_modules/firebase-admin": {
-      "version": "11.11.1",
-      "resolved": "https://registry.npmjs.org/firebase-admin/-/firebase-admin-11.11.1.tgz",
-      "integrity": "sha512-UyEbq+3u6jWzCYbUntv/HuJiTixwh36G1R9j0v71mSvGAx/YZEWEW7uSGLYxBYE6ckVRQoKMr40PYUEzrm/4dg==",
+      "version": "13.4.0",
+      "resolved": "https://registry.npmjs.org/firebase-admin/-/firebase-admin-13.4.0.tgz",
+      "integrity": "sha512-Y8DcyKK+4pl4B93ooiy1G8qvdyRMkcNFfBSh+8rbVcw4cW8dgG0VXCCTp5NUwub8sn9vSPsOwpb9tE2OuFmcfQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@fastify/busboy": "^1.2.1",
-        "@firebase/database-compat": "^0.3.4",
-        "@firebase/database-types": "^0.10.4",
-        "@types/node": ">=12.12.47",
+        "@fastify/busboy": "^3.0.0",
+        "@firebase/database-compat": "^2.0.0",
+        "@firebase/database-types": "^1.0.6",
+        "@types/node": "^22.8.7",
+        "farmhash-modern": "^1.1.0",
+        "google-auth-library": "^9.14.2",
         "jsonwebtoken": "^9.0.0",
-        "jwks-rsa": "^3.0.1",
+        "jwks-rsa": "^3.1.0",
         "node-forge": "^1.3.1",
-        "uuid": "^9.0.0"
+        "uuid": "^11.0.2"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=18"
       },
       "optionalDependencies": {
-        "@google-cloud/firestore": "^6.8.0",
-        "@google-cloud/storage": "^6.9.5"
+        "@google-cloud/firestore": "^7.11.0",
+        "@google-cloud/storage": "^7.14.0"
+      }
+    },
+    "node_modules/firebase-admin/node_modules/@types/node": {
+      "version": "22.17.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.17.2.tgz",
+      "integrity": "sha512-gL6z5N9Jm9mhY+U2KXZpteb+09zyffliRkZyZOHODGATyC5B1Jt/7TzuuiLkFsSUMLbS1OLmlj/E+/3KF4Q/4w==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/firebase-admin/node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "license": "MIT"
+    },
+    "node_modules/firebase-admin/node_modules/uuid": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
+      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/form-data": {
@@ -2205,33 +1982,78 @@
       }
     },
     "node_modules/gaxios": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-5.1.3.tgz",
-      "integrity": "sha512-95hVgBRgEIRQQQHIbnxBXeHbW4TqFk4ZDJW7wmVtvYar72FdhRIo1UGOLS2eRAKCPEdPBWu+M7+A33D9CdX9rA==",
+      "version": "6.7.1",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-6.7.1.tgz",
+      "integrity": "sha512-LDODD4TMYx7XXdpwxAVRAIAuB0bzv0s+ywFonY46k126qzQHT9ygyoa9tncmOiQmmDrik65UYsEkv3lbfqQ3yQ==",
       "license": "Apache-2.0",
-      "optional": true,
       "dependencies": {
         "extend": "^3.0.2",
-        "https-proxy-agent": "^5.0.0",
+        "https-proxy-agent": "^7.0.1",
         "is-stream": "^2.0.0",
-        "node-fetch": "^2.6.9"
+        "node-fetch": "^2.6.9",
+        "uuid": "^9.0.1"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=14"
       }
     },
-    "node_modules/gcp-metadata": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-5.3.0.tgz",
-      "integrity": "sha512-FNTkdNEnBdlqF2oatizolQqNANMrcqJt6AAYt99B3y1aLLC8Hc5IOBb+ZnnzllodEEf6xMBp6wRcBbc16fa65w==",
-      "license": "Apache-2.0",
-      "optional": true,
+    "node_modules/gaxios/node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/gaxios/node_modules/debug": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
+      "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
+      "license": "MIT",
       "dependencies": {
-        "gaxios": "^5.0.0",
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/gaxios/node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/gaxios/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/gcp-metadata": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-6.1.1.tgz",
+      "integrity": "sha512-a4tiq7E0/5fTjxPAaH4jpjkSv/uCaU2p5KC6HVGrvl0cDjA8iBZv4vv1gyzlmK0ZUKqwpOyQMKzZQe3lTit77A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "gaxios": "^6.1.1",
+        "google-logging-utils": "^0.0.2",
         "json-bigint": "^1.0.0"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=14"
       }
     },
     "node_modules/get-caller-file": {
@@ -2287,27 +2109,6 @@
       "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
       "license": "MIT"
     },
-    "node_modules/glob": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
-      "integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
-      "deprecated": "Glob versions prior to v9 are no longer supported",
-      "license": "ISC",
-      "optional": true,
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^5.0.1",
-        "once": "^1.3.0"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/glob-parent": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
@@ -2321,121 +2122,54 @@
         "node": ">= 6"
       }
     },
-    "node_modules/glob/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
-    "node_modules/glob/node_modules/minimatch": {
-      "version": "5.1.6",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
-      "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
-      "license": "ISC",
-      "optional": true,
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/google-auth-library": {
-      "version": "8.9.0",
-      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-8.9.0.tgz",
-      "integrity": "sha512-f7aQCJODJFmYWN6PeNKzgvy9LI2tYmXnzpNDHEjG5sDNPgGb2FXQyTBnXeSH+PAtpKESFD+LmHw3Ox3mN7e1Fg==",
+      "version": "9.15.1",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-9.15.1.tgz",
+      "integrity": "sha512-Jb6Z0+nvECVz+2lzSMt9u98UsoakXxA2HGHMCxh+so3n90XgYWkq5dur19JAJV7ONiJY22yBTyJB1TSkvPq9Ng==",
       "license": "Apache-2.0",
-      "optional": true,
       "dependencies": {
-        "arrify": "^2.0.0",
         "base64-js": "^1.3.0",
         "ecdsa-sig-formatter": "^1.0.11",
-        "fast-text-encoding": "^1.0.0",
-        "gaxios": "^5.0.0",
-        "gcp-metadata": "^5.3.0",
-        "gtoken": "^6.1.0",
-        "jws": "^4.0.0",
-        "lru-cache": "^6.0.0"
+        "gaxios": "^6.1.1",
+        "gcp-metadata": "^6.1.0",
+        "gtoken": "^7.0.0",
+        "jws": "^4.0.0"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=14"
       }
     },
     "node_modules/google-gax": {
-      "version": "3.6.1",
-      "resolved": "https://registry.npmjs.org/google-gax/-/google-gax-3.6.1.tgz",
-      "integrity": "sha512-g/lcUjGcB6DSw2HxgEmCDOrI/CByOwqRvsuUvNalHUK2iPPPlmAIpbMbl62u0YufGMr8zgE3JL7th6dCb1Ry+w==",
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/google-gax/-/google-gax-4.6.1.tgz",
+      "integrity": "sha512-V6eky/xz2mcKfAd1Ioxyd6nmA61gao3n01C+YeuIwu3vzM9EDR6wcVzMSIbLMDXWeoi9SHYctXuKYC5uJUT3eQ==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
-        "@grpc/grpc-js": "~1.8.0",
-        "@grpc/proto-loader": "^0.7.0",
+        "@grpc/grpc-js": "^1.10.9",
+        "@grpc/proto-loader": "^0.7.13",
         "@types/long": "^4.0.0",
-        "@types/rimraf": "^3.0.2",
         "abort-controller": "^3.0.0",
         "duplexify": "^4.0.0",
-        "fast-text-encoding": "^1.0.3",
-        "google-auth-library": "^8.0.2",
-        "is-stream-ended": "^0.1.4",
-        "node-fetch": "^2.6.1",
+        "google-auth-library": "^9.3.0",
+        "node-fetch": "^2.7.0",
         "object-hash": "^3.0.0",
-        "proto3-json-serializer": "^1.0.0",
-        "protobufjs": "7.2.4",
-        "protobufjs-cli": "1.1.1",
-        "retry-request": "^5.0.0"
-      },
-      "bin": {
-        "compileProtos": "build/tools/compileProtos.js",
-        "minifyProtoJson": "build/tools/minify.js"
+        "proto3-json-serializer": "^2.0.2",
+        "protobufjs": "^7.3.2",
+        "retry-request": "^7.0.0",
+        "uuid": "^9.0.1"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=14"
       }
     },
-    "node_modules/google-gax/node_modules/protobufjs": {
-      "version": "7.2.4",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.2.4.tgz",
-      "integrity": "sha512-AT+RJgD2sH8phPmCf7OUZR8xGdcJRga4+1cOaXJ64hvcSkVhNcRHOwIxUatPH15+nj59WAGTDv3LSGZPEQbJaQ==",
-      "hasInstallScript": true,
-      "license": "BSD-3-Clause",
-      "optional": true,
-      "dependencies": {
-        "@protobufjs/aspromise": "^1.1.2",
-        "@protobufjs/base64": "^1.1.2",
-        "@protobufjs/codegen": "^2.0.4",
-        "@protobufjs/eventemitter": "^1.1.0",
-        "@protobufjs/fetch": "^1.1.0",
-        "@protobufjs/float": "^1.0.2",
-        "@protobufjs/inquire": "^1.1.0",
-        "@protobufjs/path": "^1.1.2",
-        "@protobufjs/pool": "^1.1.0",
-        "@protobufjs/utf8": "^1.1.0",
-        "@types/node": ">=13.7.0",
-        "long": "^5.0.0"
-      },
+    "node_modules/google-logging-utils": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-0.0.2.tgz",
+      "integrity": "sha512-NEgUnEcBiP5HrPzufUkBzJOD/Sxsco3rLNo1F1TNf7ieU8ryUzBhqba8r756CjLX7rn3fHl6iLEwPYuqpoKgQQ==",
+      "license": "Apache-2.0",
       "engines": {
-        "node": ">=12.0.0"
-      }
-    },
-    "node_modules/google-p12-pem": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/google-p12-pem/-/google-p12-pem-4.0.1.tgz",
-      "integrity": "sha512-WPkN4yGtz05WZ5EhtlxNDWPhC4JIic6G8ePitwUWy4l+XPVYec+a0j0Ts47PDtW59y3RwAhUd9/h9ZZ63px6RQ==",
-      "deprecated": "Package is no longer maintained",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "node-forge": "^1.3.1"
-      },
-      "bin": {
-        "gp12-pem": "build/src/bin/gp12-pem.js"
-      },
-      "engines": {
-        "node": ">=12.0.0"
+        "node": ">=14"
       }
     },
     "node_modules/gopd": {
@@ -2458,18 +2192,16 @@
       "optional": true
     },
     "node_modules/gtoken": {
-      "version": "6.1.2",
-      "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-6.1.2.tgz",
-      "integrity": "sha512-4ccGpzz7YAr7lxrT2neugmXQ3hP9ho2gcaityLVkiUecAiwiy60Ii8gRbZeOsXV19fYaRjgBSshs8kXw+NKCPQ==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-7.1.0.tgz",
+      "integrity": "sha512-pCcEwRi+TKpMlxAQObHDQ56KawURgyAf6jtIY046fJ5tIv3zDe/LEIubckAO8fj6JnAxLdmWkUfNyulQ2iKdEw==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
-        "gaxios": "^5.0.1",
-        "google-p12-pem": "^4.0.0",
+        "gaxios": "^6.0.0",
         "jws": "^4.0.0"
       },
       "engines": {
-        "node": ">=12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/has-flag": {
@@ -2527,6 +2259,23 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/html-entities": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-2.6.0.tgz",
+      "integrity": "sha512-kig+rMn/QOVRvr7c86gQ8lWXq+Hkv6CbAH1hLu+RG338StTpE8Z0b44SDVaqVu7HGKf27frdmUYEs9hTUX/cLQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/mdevils"
+        },
+        {
+          "type": "patreon",
+          "url": "https://patreon.com/mdevils"
+        }
+      ],
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/http-cache-semantics": {
       "version": "4.2.0",
@@ -2824,44 +2573,17 @@
         "node": ">=0.12.0"
       }
     },
-    "node_modules/is-regex": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
-      "integrity": "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "call-bound": "^1.0.2",
-        "gopd": "^1.2.0",
-        "has-tostringtag": "^1.0.2",
-        "hasown": "^2.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/is-stream": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
       "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=8"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/is-stream-ended": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/is-stream-ended/-/is-stream-ended-0.1.4.tgz",
-      "integrity": "sha512-xj0XPvmr7bQFTvirqnFr50o0hQIh6ZItDqloxt5aJrR4NQsYeSsyFQERYGCAzfindAcnKjINnwEEgLx4IqVzQw==",
-      "license": "MIT",
-      "optional": true
     },
     "node_modules/isarray": {
       "version": "1.0.0",
@@ -2876,6 +2598,19 @@
       "license": "ISC",
       "optional": true
     },
+    "node_modules/joi": {
+      "version": "17.13.3",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-17.13.3.tgz",
+      "integrity": "sha512-otDA4ldcIx+ZXsKHWmp0YizCweVRZG96J10b0FevjfuncLO1oX59THoAmHkNubYJ+9gWsYsp5k8v4ib6oDv1fA==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@hapi/hoek": "^9.3.0",
+        "@hapi/topo": "^5.1.0",
+        "@sideway/address": "^4.1.5",
+        "@sideway/formula": "^3.0.1",
+        "@sideway/pinpoint": "^2.0.0"
+      }
+    },
     "node_modules/jose": {
       "version": "4.15.9",
       "resolved": "https://registry.npmjs.org/jose/-/jose-4.15.9.tgz",
@@ -2885,65 +2620,11 @@
         "url": "https://github.com/sponsors/panva"
       }
     },
-    "node_modules/js2xmlparser": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/js2xmlparser/-/js2xmlparser-4.0.2.tgz",
-      "integrity": "sha512-6n4D8gLlLf1n5mNLQPRfViYzu9RATblzPEtm1SthMX1Pjao0r9YI9nw7ZIfRxQMERS87mcswrg+r/OYrPRX6jA==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "dependencies": {
-        "xmlcreate": "^2.0.4"
-      }
-    },
-    "node_modules/jsdoc": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/jsdoc/-/jsdoc-4.0.4.tgz",
-      "integrity": "sha512-zeFezwyXeG4syyYHbvh1A967IAqq/67yXtXvuL5wnqCkFZe8I0vKfm+EO+YEvLguo6w9CDUbrAXVtJSHh2E8rw==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "dependencies": {
-        "@babel/parser": "^7.20.15",
-        "@jsdoc/salty": "^0.2.1",
-        "@types/markdown-it": "^14.1.1",
-        "bluebird": "^3.7.2",
-        "catharsis": "^0.9.0",
-        "escape-string-regexp": "^2.0.0",
-        "js2xmlparser": "^4.0.2",
-        "klaw": "^3.0.0",
-        "markdown-it": "^14.1.0",
-        "markdown-it-anchor": "^8.6.7",
-        "marked": "^4.0.10",
-        "mkdirp": "^1.0.4",
-        "requizzle": "^0.2.3",
-        "strip-json-comments": "^3.1.0",
-        "underscore": "~1.13.2"
-      },
-      "bin": {
-        "jsdoc": "jsdoc.js"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      }
-    },
-    "node_modules/jsdoc/node_modules/mkdirp": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
-      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
-      "license": "MIT",
-      "optional": true,
-      "bin": {
-        "mkdirp": "bin/cmd.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/json-bigint": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
       "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "bignumber.js": "^9.0.0"
       }
@@ -3002,7 +2683,6 @@
       "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
       "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "buffer-equal-constant-time": "^1.0.1",
         "ecdsa-sig-formatter": "1.0.11",
@@ -3054,57 +2734,15 @@
       "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.0.tgz",
       "integrity": "sha512-KDncfTmOZoOMTFG4mBlG0qUIOlc03fmzH+ru6RgYVZhPkyiy/92Owlt/8UEN+a4TXR1FQetfIpJE8ApdvdVxTg==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "jwa": "^2.0.0",
         "safe-buffer": "^5.0.1"
-      }
-    },
-    "node_modules/klaw": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/klaw/-/klaw-3.0.0.tgz",
-      "integrity": "sha512-0Fo5oir+O9jnXu5EefYbVK+mHMBeEVEy2cmctR1O1NECcCkPRreJKrS6Qt/j3KC2C148Dfo9i3pCmCMsdqGr0g==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "graceful-fs": "^4.1.9"
-      }
-    },
-    "node_modules/levn": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
-      "integrity": "sha512-0OO4y2iOHix2W6ujICbKIaEQXvFQHue65vUG3pb5EUomzPI90z9hsA1VsO/dbIIpC53J8gxM9Q4Oho0jrCM/yA==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "prelude-ls": "~1.1.2",
-        "type-check": "~0.3.2"
-      },
-      "engines": {
-        "node": ">= 0.8.0"
       }
     },
     "node_modules/limiter": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/limiter/-/limiter-1.1.5.tgz",
       "integrity": "sha512-FWWMIEOxz3GwUI4Ts/IvgVy6LPvoMPgjMdQ185nN6psJyBJ4yOpzqm695/h5umdLJg2vW3GR5iG11MAkR2AzJA=="
-    },
-    "node_modules/linkify-it": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.0.tgz",
-      "integrity": "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "uc.micro": "^2.0.0"
-      }
-    },
-    "node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "license": "MIT",
-      "optional": true
     },
     "node_modules/lodash.camelcase": {
       "version": "4.3.0",
@@ -3218,48 +2856,6 @@
         "node": ">= 10"
       }
     },
-    "node_modules/markdown-it": {
-      "version": "14.1.0",
-      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.0.tgz",
-      "integrity": "sha512-a54IwgWPaeBCAAsv13YgmALOF1elABB08FxO9i+r4VFk5Vl4pKokRPeX8u5TCgSsPi6ec1otfLjdOpVcgbpshg==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "argparse": "^2.0.1",
-        "entities": "^4.4.0",
-        "linkify-it": "^5.0.0",
-        "mdurl": "^2.0.0",
-        "punycode.js": "^2.3.1",
-        "uc.micro": "^2.1.0"
-      },
-      "bin": {
-        "markdown-it": "bin/markdown-it.mjs"
-      }
-    },
-    "node_modules/markdown-it-anchor": {
-      "version": "8.6.7",
-      "resolved": "https://registry.npmjs.org/markdown-it-anchor/-/markdown-it-anchor-8.6.7.tgz",
-      "integrity": "sha512-FlCHFwNnutLgVTflOYHPW2pPcl2AACqVzExlkGQNsi4CJgqOHN7YTgDd4LuhgN1BFO3TS0vLAruV1Td6dwWPJA==",
-      "license": "Unlicense",
-      "optional": true,
-      "peerDependencies": {
-        "@types/markdown-it": "*",
-        "markdown-it": "*"
-      }
-    },
-    "node_modules/marked": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-4.3.0.tgz",
-      "integrity": "sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A==",
-      "license": "MIT",
-      "optional": true,
-      "bin": {
-        "marked": "bin/marked.js"
-      },
-      "engines": {
-        "node": ">= 12"
-      }
-    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -3268,13 +2864,6 @@
       "engines": {
         "node": ">= 0.4"
       }
-    },
-    "node_modules/mdurl": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
-      "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
-      "license": "MIT",
-      "optional": true
     },
     "node_modules/media-typer": {
       "version": "0.3.0",
@@ -3314,16 +2903,6 @@
       },
       "engines": {
         "node": ">=10.0.0"
-      }
-    },
-    "node_modules/mime-db": {
-      "version": "1.54.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
-      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">= 0.6"
       }
     },
     "node_modules/mime-types": {
@@ -3638,19 +3217,19 @@
       }
     },
     "node_modules/nodemon": {
-      "version": "2.0.22",
-      "resolved": "https://registry.npmjs.org/nodemon/-/nodemon-2.0.22.tgz",
-      "integrity": "sha512-B8YqaKMmyuCO7BowF1Z1/mkPqLk6cs/l63Ojtd6otKjMx47Dq1utxfRxcavH1I7VSaL8n5BUaoutadnsX3AAVQ==",
+      "version": "3.1.10",
+      "resolved": "https://registry.npmjs.org/nodemon/-/nodemon-3.1.10.tgz",
+      "integrity": "sha512-WDjw3pJ0/0jMFmyNDp3gvY2YizjLmmOUQo6DEBY+JgdvW/yQ9mEeSw6H5ythl5Ny2ytb7f9C2nIbjSxMNzbJXw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "chokidar": "^3.5.2",
-        "debug": "^3.2.7",
+        "debug": "^4",
         "ignore-by-default": "^1.0.1",
         "minimatch": "^3.1.2",
         "pstree.remy": "^1.1.8",
-        "semver": "^5.7.1",
-        "simple-update-notifier": "^1.0.7",
+        "semver": "^7.5.3",
+        "simple-update-notifier": "^2.0.0",
         "supports-color": "^5.5.0",
         "touch": "^3.1.0",
         "undefsafe": "^2.0.5"
@@ -3659,7 +3238,7 @@
         "nodemon": "bin/nodemon.js"
       },
       "engines": {
-        "node": ">=8.10.0"
+        "node": ">=10"
       },
       "funding": {
         "type": "opencollective",
@@ -3667,13 +3246,21 @@
       }
     },
     "node_modules/nodemon/node_modules/debug": {
-      "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
-      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
+      "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "ms": "^2.1.1"
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
       }
     },
     "node_modules/nodemon/node_modules/ms": {
@@ -3682,16 +3269,6 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/nodemon/node_modules/semver": {
-      "version": "5.7.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
-      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver"
-      }
     },
     "node_modules/nopt": {
       "version": "5.0.0",
@@ -3786,24 +3363,6 @@
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
-      }
-    },
-    "node_modules/optionator": {
-      "version": "0.8.3",
-      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
-      "integrity": "sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "deep-is": "~0.1.3",
-        "fast-levenshtein": "~2.0.6",
-        "levn": "~0.3.0",
-        "prelude-ls": "~1.1.2",
-        "type-check": "~0.3.2",
-        "word-wrap": "~1.2.3"
-      },
-      "engines": {
-        "node": ">= 0.8.0"
       }
     },
     "node_modules/p-limit": {
@@ -3902,15 +3461,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/prelude-ls": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
-      "integrity": "sha512-ESF23V4SKG6lVSGZgYNpbsiaAkdab6ZgOxe52p7+Kid3W3u3bxR4Vfd/o21dmN7jSt0IwgZ4v5MUd26FEtXE9w==",
-      "optional": true,
-      "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
     "node_modules/process-nextick-args": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
@@ -3949,16 +3499,16 @@
       }
     },
     "node_modules/proto3-json-serializer": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/proto3-json-serializer/-/proto3-json-serializer-1.1.1.tgz",
-      "integrity": "sha512-AwAuY4g9nxx0u52DnSMkqqgyLHaW/XaPLtaAo3y/ZCfeaQB/g4YDH4kb8Wc/mWzWvu0YjOznVnfn373MVZZrgw==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/proto3-json-serializer/-/proto3-json-serializer-2.0.2.tgz",
+      "integrity": "sha512-SAzp/O4Yh02jGdRc+uIrGoe87dkN/XtwxfZ4ZyafJHymd79ozp5VG5nyZ7ygqPM5+cpLDjjGnYFUkngonyDPOQ==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
-        "protobufjs": "^7.0.0"
+        "protobufjs": "^7.2.5"
       },
       "engines": {
-        "node": ">=12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/protobufjs": {
@@ -3984,35 +3534,6 @@
       },
       "engines": {
         "node": ">=12.0.0"
-      }
-    },
-    "node_modules/protobufjs-cli": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/protobufjs-cli/-/protobufjs-cli-1.1.1.tgz",
-      "integrity": "sha512-VPWMgIcRNyQwWUv8OLPyGQ/0lQY/QTQAVN5fh+XzfDwsVw1FZ2L3DM/bcBf8WPiRz2tNpaov9lPZfNcmNo6LXA==",
-      "license": "BSD-3-Clause",
-      "optional": true,
-      "dependencies": {
-        "chalk": "^4.0.0",
-        "escodegen": "^1.13.0",
-        "espree": "^9.0.0",
-        "estraverse": "^5.1.0",
-        "glob": "^8.0.0",
-        "jsdoc": "^4.0.0",
-        "minimist": "^1.2.0",
-        "semver": "^7.1.2",
-        "tmp": "^0.2.1",
-        "uglify-js": "^3.7.7"
-      },
-      "bin": {
-        "pbjs": "bin/pbjs",
-        "pbts": "bin/pbts"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      },
-      "peerDependencies": {
-        "protobufjs": "^7.0.0"
       }
     },
     "node_modules/proxy-addr": {
@@ -4043,23 +3564,6 @@
       "dependencies": {
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"
-      }
-    },
-    "node_modules/punycode": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-      "integrity": "sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ==",
-      "license": "MIT",
-      "optional": true
-    },
-    "node_modules/punycode.js": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
-      "integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/qs": {
@@ -4162,16 +3666,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/requizzle": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/requizzle/-/requizzle-0.2.4.tgz",
-      "integrity": "sha512-JRrFk1D4OQ4SqovXOgdav+K8EAhSB/LJZqCz8tbX0KObcdeM15Ss59ozWMBWmmINMagCwmqn4ZNryUGpBsl6Jw==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "lodash": "^4.17.21"
-      }
-    },
     "node_modules/retry": {
       "version": "0.13.1",
       "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
@@ -4183,43 +3677,19 @@
       }
     },
     "node_modules/retry-request": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/retry-request/-/retry-request-5.0.2.tgz",
-      "integrity": "sha512-wfI3pk7EE80lCIXprqh7ym48IHYdwmAAzESdbU8Q9l7pnRCk9LEhpbOTNKjz6FARLm/Bl5m+4F0ABxOkYUujSQ==",
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/retry-request/-/retry-request-7.0.2.tgz",
+      "integrity": "sha512-dUOvLMJ0/JJYEn8NrpOaGNE7X3vpI5XlZS/u0ANjqtcZVKnIxP7IgCFwrKTxENw29emmwug53awKtaMm4i9g5w==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "debug": "^4.1.1",
-        "extend": "^3.0.2"
+        "@types/request": "^2.48.8",
+        "extend": "^3.0.2",
+        "teeny-request": "^9.0.0"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=14"
       }
-    },
-    "node_modules/retry-request/node_modules/debug": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
-      "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/retry-request/node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "license": "MIT",
-      "optional": true
     },
     "node_modules/rimraf": {
       "version": "3.0.2",
@@ -4279,24 +3749,6 @@
         }
       ],
       "license": "MIT"
-    },
-    "node_modules/safe-regex-test": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.1.0.tgz",
-      "integrity": "sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "call-bound": "^1.0.2",
-        "es-errors": "^1.3.0",
-        "is-regex": "^1.2.1"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
     },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
@@ -4583,26 +4035,16 @@
       }
     },
     "node_modules/simple-update-notifier": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/simple-update-notifier/-/simple-update-notifier-1.1.0.tgz",
-      "integrity": "sha512-VpsrsJSUcJEseSbMHkrsrAVSdvVS5I96Qo1QAQ4FxQ9wXFcB+pjj7FB7/us9+GcgfW4ziHtYMc1J0PLczb55mg==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/simple-update-notifier/-/simple-update-notifier-2.0.0.tgz",
+      "integrity": "sha512-a2B9Y0KlNXl9u/vsW6sTIu9vGEpfKu2wRV6l1H3XEas/0gUIzGzBoP/IouTcUQbm9JWZLH3COxyn03TYlFax6w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "semver": "~7.0.0"
+        "semver": "^7.5.3"
       },
       "engines": {
-        "node": ">=8.10.0"
-      }
-    },
-    "node_modules/simple-update-notifier/node_modules/semver": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.0.0.tgz",
-      "integrity": "sha512-+GB6zVA9LWh6zovYQLALHwv5rb2PHGlJi3lfiqIHxR0uuwCgefcOJc59v9fv1w8GbStwxuuqqAjI9NMAOOgq1A==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
+        "node": ">=10"
       }
     },
     "node_modules/smart-buffer": {
@@ -4670,16 +4112,6 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT",
       "optional": true
-    },
-    "node_modules/source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "license": "BSD-3-Clause",
-      "optional": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
     },
     "node_modules/sqlite3": {
       "version": "5.1.7",
@@ -4802,19 +4234,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/strip-json-comments": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
-      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/strnum": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.1.2.tgz",
@@ -4921,20 +4340,20 @@
       }
     },
     "node_modules/teeny-request": {
-      "version": "8.0.3",
-      "resolved": "https://registry.npmjs.org/teeny-request/-/teeny-request-8.0.3.tgz",
-      "integrity": "sha512-jJZpA5He2y52yUhA7pyAGZlgQpcB+xLjcN0eUFxr9c8hP/H7uOXbBNVo/O0C/xVfJLJs680jvkFgVJEEvk9+ww==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/teeny-request/-/teeny-request-9.0.0.tgz",
+      "integrity": "sha512-resvxdc6Mgb7YEThw6G6bExlXKkv6+YbuzGg9xuXxSgxJF7Ozs+o8Y9+2R3sArdWdW8nOokoQb1yrpFB0pQK2g==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "http-proxy-agent": "^5.0.0",
         "https-proxy-agent": "^5.0.0",
-        "node-fetch": "^2.6.1",
+        "node-fetch": "^2.6.9",
         "stream-events": "^1.0.5",
         "uuid": "^9.0.0"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=14"
       }
     },
     "node_modules/teeny-request/node_modules/@tootallnate/once": {
@@ -4996,22 +4415,6 @@
         "b4a": "^1.6.4"
       }
     },
-    "node_modules/text-decoding": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/text-decoding/-/text-decoding-1.0.0.tgz",
-      "integrity": "sha512-/0TJD42KDnVwKmDK6jj3xP7E2MG7SHAOG4tyTgyUCRPdHwvkquYNLEQltmdMa3owq3TkddCVcTsoctJI8VQNKA==",
-      "license": "MIT"
-    },
-    "node_modules/tmp": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
-      "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=14.14"
-      }
-    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -5068,19 +4471,6 @@
         "node": "*"
       }
     },
-    "node_modules/type-check": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
-      "integrity": "sha512-ZCmOJdvOWDBYJlzAoFkC+Q0+bUyEOS1ltgp1MGU03fqHG+dbi9tBFU2Rd9QKiDZFAYrhPh2JUf7rZRIuHRKtOg==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "prelude-ls": "~1.1.2"
-      },
-      "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
     "node_modules/type-is": {
       "version": "1.6.18",
       "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
@@ -5100,39 +4490,12 @@
       "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==",
       "license": "MIT"
     },
-    "node_modules/uc.micro": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
-      "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
-      "license": "MIT",
-      "optional": true
-    },
-    "node_modules/uglify-js": {
-      "version": "3.19.3",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.19.3.tgz",
-      "integrity": "sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==",
-      "license": "BSD-2-Clause",
-      "optional": true,
-      "bin": {
-        "uglifyjs": "bin/uglifyjs"
-      },
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
     "node_modules/undefsafe": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/undefsafe/-/undefsafe-2.0.5.tgz",
       "integrity": "sha512-WxONCrssBM8TSPRqN5EmsjVrsv4A8X12J4ArBiiayv3DyyG3ZlIg6yysuuSYdZsVz3TKcTg2fd//Ujd4CHV1iA==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/underscore": {
-      "version": "1.13.7",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.7.tgz",
-      "integrity": "sha512-GMXzWtsc57XAtguZgaQViUOzs0KTkk8ojr3/xAxXLITqf/3EMwxC0inyETfDFjH/Krbhuep0HNbbjI9i/q3F3g==",
-      "license": "MIT",
-      "optional": true
     },
     "node_modules/undici-types": {
       "version": "7.10.0",
@@ -5271,16 +4634,6 @@
         "string-width": "^1.0.2 || 2 || 3 || 4"
       }
     },
-    "node_modules/word-wrap": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
-      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/wrap-ansi": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
@@ -5304,13 +4657,6 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC"
-    },
-    "node_modules/xmlcreate": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/xmlcreate/-/xmlcreate-2.0.4.tgz",
-      "integrity": "sha512-nquOebG4sngPmGPICTS5EnxqhKbCmz5Ox5hsszI2T6U5qdrJizBc+0ilYSEjTSzU0yZcmvppztXe/5Al5fUwdg==",
-      "license": "Apache-2.0",
-      "optional": true
     },
     "node_modules/xtend": {
       "version": "4.0.2",

--- a/backend/routes/rios.js
+++ b/backend/routes/rios.js
@@ -6,6 +6,9 @@ const sqlite3 = require('sqlite3').verbose();
 const { optional } = require('../middleware/firebaseAuth');
 const { createRiosSchema } = require('../validation/riosSchema');
 
+const MAX_MEDIA = process.env.MAX_MEDIA ? Number(process.env.MAX_MEDIA) : 20;
+const MAX_WAYPOINTS = process.env.MAX_WAYPOINTS ? Number(process.env.MAX_WAYPOINTS) : 200;
+
 function isNumberFinite(v) { return v !== null && v !== undefined && !Number.isNaN(Number(v)) && Number.isFinite(Number(v)); }
 
 // GET /api/rios
@@ -23,6 +26,27 @@ router.post('/', optional, (req, res) => {
   const { error, value } = createRiosSchema.validate(req.body, { abortEarly: false, allowUnknown: true });
   if (error) return res.status(400).json({ error: 'Validation failed' });
   req.body = value;
+
+  // enforce configured limits and transform waypoints -> LineString
+  if (Array.isArray(req.body.multimedia) && req.body.multimedia.length > MAX_MEDIA) {
+    return res.status(422).json({ error: `Too many multimedia items (max ${MAX_MEDIA})` });
+  }
+  if (Array.isArray(req.body.waypoints)) {
+    if (req.body.waypoints.length > MAX_WAYPOINTS) {
+      return res.status(422).json({ error: `Too many waypoints (max ${MAX_WAYPOINTS})` });
+    }
+    // convert waypoints to LineString geometry if present
+    const coords = [];
+    for (const wp of req.body.waypoints) {
+      if (wp && isNumberFinite(wp.lat) && isNumberFinite(wp.lng)) {
+        coords.push([Number(wp.lng), Number(wp.lat)]);
+      }
+    }
+    if (coords.length > 0) {
+      // override/define geometry as LineString
+      req.body.geometry = { type: 'LineString', coordinates: coords };
+    }
+  }
 
   const nombre = req.body.nombre || req.body.title || '';
   const descripcion = req.body.descripcion || req.body.description || '';

--- a/backend/routes/rios.js
+++ b/backend/routes/rios.js
@@ -54,12 +54,17 @@ router.post('/', optional, (req, res) => {
   const dificultad = req.body.dificultad || req.body.dificulty || 'medio';
   const duracion_estimada = req.body.duracion_estimada || req.body.duracion_estimated || null;
 
-  // prefer explicit lat/lng or point geometry
+  // prefer explicit lat/lng or point/linestring geometry
   let geometry = null, repLat = null, repLng = null;
-  if (req.body.geometry && req.body.geometry.type === 'Point' && Array.isArray(req.body.geometry.coordinates)) {
-    geometry = req.body.geometry;
-    repLng = Number(geometry.coordinates[0]);
-    repLat = Number(geometry.coordinates[1]);
+  if (req.body.geometry && Array.isArray(req.body.geometry.coordinates)) {
+    if (req.body.geometry.type === 'Point') {
+      geometry = req.body.geometry;
+      repLng = Number(geometry.coordinates[0]);
+      repLat = Number(geometry.coordinates[1]);
+    } else if (req.body.geometry.type === 'LineString') {
+      // keep linestring geometry as-is
+      geometry = req.body.geometry;
+    }
   } else if (isNumberFinite(req.body.lat) && isNumberFinite(req.body.lng)) {
     repLat = Number(req.body.lat);
     repLng = Number(req.body.lng);

--- a/backend/routes/rios.js
+++ b/backend/routes/rios.js
@@ -1,9 +1,12 @@
 const express = require('express');
 const router = express.Router();
 const { v4: uuidv4 } = require('uuid');
-const fs = require('fs');
 const { dbPath } = require('../db/sqlite');
 const sqlite3 = require('sqlite3').verbose();
+const { optional } = require('../middleware/firebaseAuth');
+const { createRiosSchema } = require('../validation/riosSchema');
+
+function isNumberFinite(v) { return v !== null && v !== undefined && !Number.isNaN(Number(v)) && Number.isFinite(Number(v)); }
 
 // GET /api/rios
 router.get('/', (req, res) => {
@@ -11,120 +14,61 @@ router.get('/', (req, res) => {
   db.all('SELECT * FROM rios', (err, rows) => {
     db.close();
     if (err) return res.status(500).json({ error: err.message });
-    return res.json(rows);
+    res.json(rows);
   });
 });
 
 // POST /api/rios
-const { optional } = require('../middleware/firebaseAuth');
-const { createRiosSchema } = require('../validation/riosSchema');
-// use optional auth for route creation so tests and unauthenticated clients can create entries
 router.post('/', optional, (req, res) => {
-  // Validate body with Joi
   const { error, value } = createRiosSchema.validate(req.body, { abortEarly: false, allowUnknown: true });
-  if (error) {
-    return res.status(400).json({ error: 'Validation failed', details: error.details.map(d => ({ path: d.path, message: d.message })) });
-  }
-  // Replace req.body with validated/normalized value for downstream logic
+  if (error) return res.status(400).json({ error: 'Validation failed' });
   req.body = value;
-  // Accept multiple aliases from clients (e.g., mobile uses 'title')
+
   const nombre = req.body.nombre || req.body.title || '';
   const descripcion = req.body.descripcion || req.body.description || '';
   const categoria = req.body.categoria || 'general';
   const dificultad = req.body.dificultad || req.body.dificulty || 'medio';
   const duracion_estimada = req.body.duracion_estimada || req.body.duracion_estimated || null;
 
-  const geometryIn = req.body.geometry;
-  const waypoints = req.body.waypoints;
-  const MAX_WAYPOINTS = Number(process.env.MAX_WAYPOINTS || 200);
-  const multimedia = req.body.multimedia;
-  const MAX_MEDIA = Number(process.env.MAX_MEDIA || 20);
-
-  // Reject too many waypoints early
-  if (Array.isArray(waypoints) && waypoints.length > MAX_WAYPOINTS) {
-    return res.status(422).json({ error: `Too many waypoints (max=${MAX_WAYPOINTS})` });
-  }
-  // Reject too many multimedia items
-  if (Array.isArray(multimedia) && multimedia.length > MAX_MEDIA) {
-    return res.status(422).json({ error: `Too many multimedia items (max=${MAX_MEDIA})` });
-  }
-  const latIn = req.body.lat;
-  const lngIn = req.body.lng;
-
-  function isNumberFinite(v) {
-    return v !== null && v !== undefined && !Number.isNaN(Number(v)) && Number.isFinite(Number(v));
-  }
-
-  // Normalize geometry into valid GeoJSON (Point or LineString) or null
-  let normalized = null;
-  try {
-    if (geometryIn && typeof geometryIn === 'object' && geometryIn.type) {
-      // Accept GeoJSON Point and LineString
-      if (geometryIn.type === 'Point' && Array.isArray(geometryIn.coordinates) && geometryIn.coordinates.length >= 2) {
-        const lon = Number(geometryIn.coordinates[0]);
-        const lat = Number(geometryIn.coordinates[1]);
-        if (!isNumberFinite(lon) || !isNumberFinite(lat)) return res.status(400).json({ error: 'Invalid geometry coordinates' });
-        normalized = { type: 'Point', coordinates: [lon, lat] };
-      } else if (geometryIn.type === 'LineString' && Array.isArray(geometryIn.coordinates)) {
-        const coords = [];
-        for (const c of geometryIn.coordinates) {
-          if (!Array.isArray(c) || c.length < 2) return res.status(400).json({ error: 'Invalid LineString coordinates' });
-          const lon = Number(c[0]);
-          const lat = Number(c[1]);
-          if (!isNumberFinite(lon) || !isNumberFinite(lat)) return res.status(400).json({ error: 'Invalid LineString coordinate values' });
-          coords.push([lon, lat]);
-        }
-        normalized = { type: 'LineString', coordinates: coords };
-      } else {
-        return res.status(400).json({ error: 'Unsupported geometry type. Only Point and LineString are accepted.' });
-      }
-    } else if (Array.isArray(waypoints) && waypoints.length > 0) {
-      // waypoints expected as [{lat:..., lng:...}, ...]
-      const coords = [];
-      for (const w of waypoints) {
-        const lat = Number(w.lat);
-        const lon = Number(w.lng);
-        if (!isNumberFinite(lon) || !isNumberFinite(lat)) return res.status(400).json({ error: 'Invalid waypoint coordinates' });
-        coords.push([lon, lat]);
-      }
-      if (coords.length === 1) normalized = { type: 'Point', coordinates: coords[0] };
-      else normalized = { type: 'LineString', coordinates: coords };
-    } else if (isNumberFinite(latIn) && isNumberFinite(lngIn)) {
-      // Accept lat/lng top-level values
-      normalized = { type: 'Point', coordinates: [Number(lngIn), Number(latIn)] };
-    } else {
-      // geometry not provided; allow null geometry but warn client
-      normalized = null;
-    }
-  } catch (e) {
-    return res.status(400).json({ error: 'Invalid geometry payload' });
-  }
-
-  // Representative lat/lng for quick queries (use first coord for LineString)
-  let repLat = null;
-  let repLng = null;
-  if (normalized && normalized.type === 'Point' && Array.isArray(normalized.coordinates)) {
-    repLng = normalized.coordinates[0];
-    repLat = normalized.coordinates[1];
-  } else if (normalized && normalized.type === 'LineString' && Array.isArray(normalized.coordinates) && normalized.coordinates.length > 0) {
-    repLng = normalized.coordinates[0][0];
-    repLat = normalized.coordinates[0][1];
+  // prefer explicit lat/lng or point geometry
+  let geometry = null, repLat = null, repLng = null;
+  if (req.body.geometry && req.body.geometry.type === 'Point' && Array.isArray(req.body.geometry.coordinates)) {
+    geometry = req.body.geometry;
+    repLng = Number(geometry.coordinates[0]);
+    repLat = Number(geometry.coordinates[1]);
+  } else if (isNumberFinite(req.body.lat) && isNumberFinite(req.body.lng)) {
+    repLat = Number(req.body.lat);
+    repLng = Number(req.body.lng);
+    geometry = { type: 'Point', coordinates: [repLng, repLat] };
   }
 
   const id = uuidv4();
   const db = new sqlite3.Database(dbPath);
   db.run(
     'INSERT INTO rios (id,nombre,descripcion,categoria,dificultad,duracion_estimada,geometry,lat,lng) VALUES (?,?,?,?,?,?,?,?,?)',
-    [id, nombre, descripcion, categoria, dificultad, duracion_estimada, normalized ? JSON.stringify(normalized) : null, repLat, repLng],
+    [id, nombre, descripcion, categoria, dificultad, duracion_estimada, geometry ? JSON.stringify(geometry) : null, repLat, repLng],
     function (err) {
       db.close();
       if (err) return res.status(500).json({ error: err.message });
-      return res.status(201).json({ id, geometry: normalized });
+      res.status(201).json({ id, geometry });
     }
   );
 });
 
-// GET /api/rios/:id/gpx  -> export simple GPX for a route
+// Helper to normalize geometry for GPX export
+function normalizeGeometry(g) {
+  if (!g || !g.type || !Array.isArray(g.coordinates)) return null;
+  const t = g.type;
+  if (t === 'Point') return { type: 'Point', coordinates: g.coordinates };
+  if (t === 'LineString') return { type: 'LineString', coordinates: g.coordinates };
+  if (t === 'Polygon' && Array.isArray(g.coordinates) && Array.isArray(g.coordinates[0])) {
+    // take first ring as line
+    return { type: 'LineString', coordinates: g.coordinates[0] };
+  }
+  return null;
+}
+
+// GET /api/rios/:id/gpx
 router.get('/:id/gpx', (req, res) => {
   const id = req.params.id;
   const db = new sqlite3.Database(dbPath);
@@ -132,53 +76,33 @@ router.get('/:id/gpx', (req, res) => {
     db.close();
     if (err) return res.status(500).json({ error: err.message });
     if (!row) return res.status(404).json({ error: 'Not found' });
-
     let geom = null;
-    try {
-      geom = row.geometry ? JSON.parse(row.geometry) : null;
-    } catch (e) {
-      geom = null;
-    }
+    try { geom = row.geometry ? JSON.parse(row.geometry) : null; } catch (e) { geom = null; }
+    const name = (row.nombre || 'ruta').toString().replace(/[^a-z0-9\-_. ]/ig, '');
+    let gpx = '<?xml version="1.0" encoding="UTF-8"?>\n';
+    gpx += '<gpx version="1.1" creator="rios-backend">\n';
 
-    function esc(s) {
-      if (!s && s !== 0) return '';
-      return String(s).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;').replace(/'/g, '&apos;');
-    }
-
-    const name = esc(row.nombre || 'ruta');
-    const desc = esc(row.descripcion || '');
-
-    let gpx = '<?xml version="1.0" encoding="UTF-8"?>\\n';
-    gpx += '<gpx version="1.1" creator="rios-backend" xmlns="http://www.topografix.com/GPX/1/1">\\n';
-    gpx += `  <metadata><name>${name}</name><desc>${desc}</desc></metadata>\\n`;
-
-    if (geom && geom.type === 'LineString' && Array.isArray(geom.coordinates)) {
-      gpx += '  <trk>\\n';
-      gpx += `    <name>${name}</name>\\n`;
-      gpx += '    <trkseg>\\n';
-      for (const c of geom.coordinates) {
-        const lon = c[0];
-        const lat = c[1];
-        gpx += `      <trkpt lat=\"${lat}\" lon=\"${lon}\"></trkpt>\\n`;
+    const n = normalizeGeometry(geom);
+    if (n && n.type === 'LineString') {
+      gpx += '  <trk>\n    <trkseg>\n';
+      for (const c of n.coordinates) {
+        const lon = c[0] != null ? c[0] : 0;
+        const lat = c[1] != null ? c[1] : 0;
+        gpx += `      <trkpt lat="${lat}" lon="${lon}"></trkpt>\n`;
       }
-      gpx += '    </trkseg>\\n';
-      gpx += '  </trk>\\n';
-    } else if (geom && geom.type === 'Point' && Array.isArray(geom.coordinates)) {
-      const lon = geom.coordinates[0];
-      const lat = geom.coordinates[1];
-      gpx += `  <wpt lat=\"${lat}\" lon=\"${lon}\"><name>${name}</name></wpt>\\n`;
+      gpx += '    </trkseg>\n  </trk>\n';
+    } else if (n && n.type === 'Point') {
+      const lon = n.coordinates[0] != null ? n.coordinates[0] : 0;
+      const lat = n.coordinates[1] != null ? n.coordinates[1] : 0;
+      gpx += `  <wpt lat="${lat}" lon="${lon}"><name>${name}</name></wpt>\n`;
     } else {
-      // fallback: no geometry, return minimal gpx with name only
-      gpx += `  <wpt lat=\"0\" lon=\"0\"><name>${name}</name><desc>No geometry available</desc></wpt>\\n`;
+      gpx += `  <wpt lat="0" lon="0"><name>${name}</name></wpt>\n`;
     }
-
-    gpx += '</gpx>\\n';
-
+    gpx += '</gpx>\n';
     res.setHeader('Content-Type', 'application/gpx+xml; charset=utf-8');
-    res.setHeader('Content-Disposition', `attachment; filename=\"${name}.gpx\"`);
-    return res.send(gpx);
+    res.setHeader('Content-Disposition', `attachment; filename="${name}.gpx"`);
+    res.send(gpx);
   });
 });
 
 module.exports = router;
-          if (coords.length === 1) normalized = { type: 'Point', coordinates: coords[0] };

--- a/backend/routes/rios.js
+++ b/backend/routes/rios.js
@@ -124,8 +124,6 @@ router.post('/', optional, (req, res) => {
   );
 });
 
-module.exports = router;
-
 // GET /api/rios/:id/gpx  -> export simple GPX for a route
 router.get('/:id/gpx', (req, res) => {
   const id = req.params.id;
@@ -150,34 +148,37 @@ router.get('/:id/gpx', (req, res) => {
     const name = esc(row.nombre || 'ruta');
     const desc = esc(row.descripcion || '');
 
-    let gpx = '<?xml version="1.0" encoding="UTF-8"?>\n';
-    gpx += '<gpx version="1.1" creator="rios-backend" xmlns="http://www.topografix.com/GPX/1/1">\n';
-    gpx += `  <metadata><name>${name}</name><desc>${desc}</desc></metadata>\n`;
+    let gpx = '<?xml version="1.0" encoding="UTF-8"?>\\n';
+    gpx += '<gpx version="1.1" creator="rios-backend" xmlns="http://www.topografix.com/GPX/1/1">\\n';
+    gpx += `  <metadata><name>${name}</name><desc>${desc}</desc></metadata>\\n`;
 
     if (geom && geom.type === 'LineString' && Array.isArray(geom.coordinates)) {
-      gpx += '  <trk>\n';
-      gpx += `    <name>${name}</name>\n`;
-      gpx += '    <trkseg>\n';
+      gpx += '  <trk>\\n';
+      gpx += `    <name>${name}</name>\\n`;
+      gpx += '    <trkseg>\\n';
       for (const c of geom.coordinates) {
         const lon = c[0];
         const lat = c[1];
-        gpx += `      <trkpt lat="${lat}" lon="${lon}"></trkpt>\n`;
+        gpx += `      <trkpt lat=\"${lat}\" lon=\"${lon}\"></trkpt>\\n`;
       }
-      gpx += '    </trkseg>\n';
-      gpx += '  </trk>\n';
+      gpx += '    </trkseg>\\n';
+      gpx += '  </trk>\\n';
     } else if (geom && geom.type === 'Point' && Array.isArray(geom.coordinates)) {
       const lon = geom.coordinates[0];
       const lat = geom.coordinates[1];
-      gpx += `  <wpt lat="${lat}" lon="${lon}"><name>${name}</name></wpt>\n`;
+      gpx += `  <wpt lat=\"${lat}\" lon=\"${lon}\"><name>${name}</name></wpt>\\n`;
     } else {
       // fallback: no geometry, return minimal gpx with name only
-      gpx += `  <wpt lat="0" lon="0"><name>${name}</name><desc>No geometry available</desc></wpt>\n`;
+      gpx += `  <wpt lat=\"0\" lon=\"0\"><name>${name}</name><desc>No geometry available</desc></wpt>\\n`;
     }
 
-    gpx += '</gpx>\n';
+    gpx += '</gpx>\\n';
 
     res.setHeader('Content-Type', 'application/gpx+xml; charset=utf-8');
-    res.setHeader('Content-Disposition', `attachment; filename="${name}.gpx"`);
+    res.setHeader('Content-Disposition', `attachment; filename=\"${name}.gpx\"`);
     return res.send(gpx);
   });
 });
+
+module.exports = router;
+          if (coords.length === 1) normalized = { type: 'Point', coordinates: coords[0] };


### PR DESCRIPTION
Resumen:
- Corrección y limpieza de backend/routes/rios.js (fix duplicados y errores de sintaxis).
- Añadido workflow para crear PRs desde la rama chore/migrations-docs con fallback a secret CREATE_PR_PAT.
- Añadida documentación: .github/RUN_WORKFLOW.md con instrucciones para ejecutar el workflow.

Qué probar localmente:
1) Revisar `backend/routes/rios.js` y ejecutar: `node -e "require('./backend/routes/rios.js')"`
2) Ejecutar checks del backend: `npm --prefix backend run check`

Notas:
- La creación automática de PRs por Actions requiere un PAT en el secret `CREATE_PR_PAT` si la política del repo bloquea GITHUB_TOKEN.
